### PR TITLE
@starsirius: orchestration presenter for GET /accounts/:id v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ end
 group :test do
   gem 'fabrication'
   gem 'rspec'
+  gem 'shoulda-matchers'
   gem 'rack-test'
   gem 'simplecov'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
     safe_yaml (1.0.4)
     shotgun (0.9.1)
       rack (>= 1.0)
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -231,5 +233,6 @@ DEPENDENCIES
   rspec
   rubocop
   shotgun
+  shoulda-matchers
   simplecov
   webmock

--- a/app/api/v2/presenters/account_presenter.rb
+++ b/app/api/v2/presenters/account_presenter.rb
@@ -8,10 +8,9 @@ module V2
       property :created_at, writeable: false, type: DateTime, desc: 'Account created timestamp.'
       property :updated_at, writeable: false, type: DateTime, desc: 'Account updated timestamp.'
 
-      link :self do |opts|
-        request = Grape::Request.new(opts[:env])
-        "#{request.base_url}/accounts/#{id}"
-      end
+      collection :features, extend: FeaturePresenter, class: Feature
+      collection :messages, extend: MessagePresenter, class: Message
+      collection :routes, extend: RoutePresenter, class: Route
     end
   end
 end

--- a/app/api/v2/presenters/feature_presenter.rb
+++ b/app/api/v2/presenters/feature_presenter.rb
@@ -1,0 +1,9 @@
+module V2
+  module Presenters
+    module FeaturePresenter
+      include Gris::Presenter
+      property :name, writeable: true, type: String, desc: 'Feature name.'
+      property :value, writeable: true, type: String, desc: 'Feature value.'
+    end
+  end
+end

--- a/app/api/v2/presenters/message_presenter.rb
+++ b/app/api/v2/presenters/message_presenter.rb
@@ -1,0 +1,9 @@
+module V2
+  module Presenters
+    module MessagePresenter
+      include Gris::Presenter
+      property :name, writeable: true, type: String, desc: 'Message name.'
+      property :content, writeable: true, type: String, desc: 'Message content.'
+    end
+  end
+end

--- a/app/api/v2/presenters/route_presenter.rb
+++ b/app/api/v2/presenters/route_presenter.rb
@@ -1,0 +1,9 @@
+module V2
+  module Presenters
+    module RoutePresenter
+      include Gris::Presenter
+      property :name, writeable: true, type: String, desc: 'Route name.'
+      property :path, writeable: true, type: String, desc: 'Route path.'
+    end
+  end
+end

--- a/app/models/concerns/accountable.rb
+++ b/app/models/concerns/accountable.rb
@@ -1,0 +1,7 @@
+module Accountable
+  extend ActiveSupport::Concern
+  included do
+    belongs_to :account, touch: true
+    validates :account, presence: true
+  end
+end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,4 +1,3 @@
 class Feature < ActiveRecord::Base
-  belongs_to :account
-  validates :account, presence: true
+  include ::Accountable
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,3 @@
 class Message < ActiveRecord::Base
-  belongs_to :account
-  validates :account, presence: true
+  include ::Accountable
 end

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -1,4 +1,3 @@
 class Route < ActiveRecord::Base
-  belongs_to :account
-  validates :account, presence: true
+  include ::Accountable
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,7 +4,7 @@ require File.expand_path('../boot', __FILE__)
 Dir['./config/initializers/**/*.rb'].map { |file| require file }
 
 # autoload app
-relative_file_paths = %w(app/models app/api app/api/v1/endpoints app/api/v1/presenters app/api/v2/endpoints app/api/v2/presenters)
+relative_file_paths = %w(app/models app/models/concerns app/api app/api/v1/endpoints app/api/v1/presenters app/api/v2/endpoints app/api/v2/presenters)
 ActiveSupport::Dependencies.autoload_paths += relative_file_paths
 
 module Echo

--- a/spec/api/v2/accounts_endpoint_spec.rb
+++ b/spec/api/v2/accounts_endpoint_spec.rb
@@ -18,9 +18,28 @@ describe V2::Endpoints::AccountsEndpoint do
       expect(account.name).to eq account_details[:name]
     end
 
-    it 'does not return a link to associated features' do
+    it 'returns associated features array' do
+      2.times do
+        Fabricate(:feature, account: account1)
+      end
       account = client.account(id: account1.id)
-      expect(account.try(:features)).to be_nil
+      expect(account.features.count).to eq 2
+    end
+
+    it 'returns associated messages array' do
+      2.times do
+        Fabricate(:message, account: account1)
+      end
+      account = client.account(id: account1.id)
+      expect(account.messages.count).to eq 2
+    end
+
+    it 'returns associated routes array' do
+      2.times do
+        Fabricate(:route, account: account1)
+      end
+      account = client.account(id: account1.id)
+      expect(account.routes.count).to eq 2
     end
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Account do
-  it 'validates that a name is present' do
-    expect(subject).to be_invalid
-    expect(subject.errors.messages).to eq(name: ["can't be blank"])
+  it { should validate_presence_of(:name) }
+  [:features, :messages, :routes].each do |association|
+    it { should have_many(association).order(:created_at) }
   end
 end

--- a/spec/models/feature_spec.rb
+++ b/spec/models/feature_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe Feature do
-  it 'validates that an account is present' do
-    expect(subject).to be_invalid
-    expect(subject.errors.messages).to eq(account: ["can't be blank"])
-  end
+  it { should belong_to(:account).touch(true) }
+  it { should validate_presence_of(:account) }
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe Message do
-  it 'validates that an account is present' do
-    expect(subject).to be_invalid
-    expect(subject.errors.messages).to eq(account: ["can't be blank"])
-  end
+  it { should belong_to(:account).touch(true) }
+  it { should validate_presence_of(:account) }
 end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe Route do
-  it 'validates that an account is present' do
-    expect(subject).to be_invalid
-    expect(subject.errors.messages).to eq(account: ["can't be blank"])
-  end
+  it { should belong_to(:account).touch(true) }
+  it { should validate_presence_of(:account) }
 end


### PR DESCRIPTION
This API endpoint will permit the mobile apps to get all the content for each account in a single call. 

Also, notably,

* Moves shared `belongs_to` relations for `Feature`, `Message`, and `Route` into an `Accountable` concern.
* touch accounts when relation is modified
* adds [shoulda-matchers](https://github.com/thoughtbot/shoulda-matchers) for activerecord spec convenience

Thanks!

![image](https://cloud.githubusercontent.com/assets/197336/8480151/2b5141b8-20aa-11e5-816f-34a00f0e659e.png)

Closes #9 
Closes #7 
