### PR TITLE
Makes Updated-At header use ISO8601 formatting

### DIFF
--- a/app/api/v2/endpoints/accounts_endpoint.rb
+++ b/app/api/v2/endpoints/accounts_endpoint.rb
@@ -8,7 +8,7 @@ module V2
         end
         get ':id' do
           account = Account.find params[:id]
-          header 'Updated-At', account.updated_at.to_json.tr("\"", "")
+          header 'Updated-At', account.updated_at.iso8601(3)
           present account, with: Presenters::AccountPresenter
         end
       end

--- a/app/api/v2/endpoints/accounts_endpoint.rb
+++ b/app/api/v2/endpoints/accounts_endpoint.rb
@@ -8,7 +8,7 @@ module V2
         end
         get ':id' do
           account = Account.find params[:id]
-          header 'Updated-At', account.updated_at.to_s
+          header 'Updated-At', account.updated_at.to_json.tr("\"", "")
           present account, with: Presenters::AccountPresenter
         end
       end

--- a/spec/api/v2/accounts_endpoint_spec.rb
+++ b/spec/api/v2/accounts_endpoint_spec.rb
@@ -23,8 +23,8 @@ describe V2::Endpoints::AccountsEndpoint do
 
     it 'returns custom Updated-At header identical to account created_at' do
       get "/accounts/#{account1.id}", {},
-           'HTTP_ACCEPT' => 'application/vnd.echo-v2+json',
-           'HTTP_AUTHORIZATION' => permitted_token
+          'HTTP_ACCEPT' => 'application/vnd.echo-v2+json',
+          'HTTP_AUTHORIZATION' => permitted_token
       body = JSON.parse(last_response.body)
       expect(last_response.headers['Updated-At']).to eq body['updated_at']
     end

--- a/spec/api/v2/accounts_endpoint_spec.rb
+++ b/spec/api/v2/accounts_endpoint_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'json'
 
 describe V2::Endpoints::AccountsEndpoint do
   include Rack::Test::Methods
@@ -17,7 +18,15 @@ describe V2::Endpoints::AccountsEndpoint do
            'HTTP_ACCEPT' => 'application/vnd.echo-v2+json',
            'HTTP_AUTHORIZATION' => permitted_token
       expect(last_response.status).to eq(200)
-      expect(last_response.headers['Updated-At']).to eq account1.updated_at.to_s
+      expect(Time.parse(last_response.headers['Updated-At'])).to be_within(1.second).of account1.updated_at
+    end
+
+    it 'returns custom Updated-At header identical to account created_at' do
+      get "/accounts/#{account1.id}", {},
+           'HTTP_ACCEPT' => 'application/vnd.echo-v2+json',
+           'HTTP_AUTHORIZATION' => permitted_token
+      body = JSON.parse(last_response.body)
+      expect(last_response.headers['Updated-At']).to eq body['updated_at']
     end
 
     it 'returns account' do


### PR DESCRIPTION
This is a follow-up from https://github.com/artsy/Aerodramus/issues/3. 

As far as I can tell, the JSON in the response uses the following line to parse the date:

https://github.com/ruby-grape/grape-roar/blob/7d543070648c1e8e74022ce3a6f8e1568f6081cd/lib/grape/roar/formatter.rb#L8

But we were using `to_s`, causing inconsistencies on clients. This PR moves the `Updated-At` header to use the same code.

I'm not sure why, but `to_json` is returning a string with quotes in it: `"\"2019-03-19T14:19:21+00:00\""`. I've added `.tr` to remove them, but I'm open to better suggestions.