### PR TITLE
chore: add AROptionsNewShowPage flag to rollout new show page

### DIFF
--- a/Echo.json
+++ b/Echo.json
@@ -21,7 +21,8 @@
     { "name": "AROptionsEnableSales", "value": true },
     { "name": "AREnableViewingRooms", "value": true },
     { "name": "AROptionsArtistSeries", "value": true },
-    { "name": "AROptionsNewFairPage", "value": false }
+    { "name": "AROptionsNewFairPage", "value": false },
+    { "name": "AROptionsNewShowPage", "value": true }
   ],
   "messages": [
     { "name": "LiveAuctionsCurrentWebSocketVersion", "content": "3" },


### PR DESCRIPTION
### Description

We're ready to roll out the new show screen with the next iOS release.

The PR which switches from the using lab option UI to the echo flag in Eigen is here: https://github.com/artsy/eigen/pull/4118

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json` and in CI, or I have not changed anything in that file.
