### PR TITLE
feat: add react native web view flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -28,6 +28,7 @@
     { name: 'AROptionsNewSalePage', value: true },
     { name: 'AREnableCustomSharesheet', value: true },
     { name: 'AROptionsNewInsightsPage', value: false },
+    { name: 'AREnableReactNativeWebView', value: true },
     { name: 'AROptionsNewArtistInsightsPage', value: true },
   ],
   messages: [


### PR DESCRIPTION
### Description

This PR adds a flag for the react native web views. The flag in eigen is called something different. That is necessary because the eigen flag predates the features.ts refactor. So if we called this one the same thing then it will switch on the feature in older versions of the app 🙅‍♀️

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
