### PR TITLE
marking "old flags"

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -6,7 +6,7 @@
   features: [
     { name: 'ipad_vir', value: false },
     { name: 'iphone_vir', value: true },
-    { name: 'ARDisableReactNativeBidFlow', value: false },
+    { name: 'ARDisableReactNativeBidFlow', value: false }, // old flag
     { name: 'AREnableBuyNowFlow', value: true },
     { name: 'AREnableMakeOfferFlow', value: true },
     { name: 'AREnableLocalDiscovery', value: true },
@@ -14,20 +14,20 @@
     { name: 'ARReactNativeArtworkEnableNonCommercial', value: true },
     { name: 'ARReactNativeArtworkEnableNSOInquiry', value: true },
     { name: 'ARReactNativeArtworkEnableAuctions', value: true },
-    { name: 'AROptionsPriceTransparency', value: true },
-    { name: 'AREnableNewPartnerView', value: true },
+    { name: 'AROptionsPriceTransparency', value: true }, // old flag
+    { name: 'AREnableNewPartnerView', value: true }, // old flag
     { name: 'AREnableNewSearch', value: true },
-    { name: 'AROptionsLotConditionReport', value: true },
+    { name: 'AROptionsLotConditionReport', value: true }, // old flag
     { name: 'AROptionsEnableSales', value: true },
-    { name: 'AREnableViewingRooms', value: true },
-    { name: 'AROptionsNewFirstInquiry', value: true },
-    { name: 'AROptionsBidManagement', value: true },
-    { name: 'AROptionsArtistSeries', value: true },
+    { name: 'AREnableViewingRooms', value: true }, // old flag
+    { name: 'AROptionsNewFirstInquiry', value: true }, // old flag
+    { name: 'AROptionsBidManagement', value: true }, // old flag
+    { name: 'AROptionsArtistSeries', value: true }, // old flag
     { name: 'AROptionsNewFairPage', value: true },
     { name: 'AROptionsNewShowPage', value: true },
-    { name: 'AROptionsNewSalePage', value: true },
+    { name: 'AROptionsNewSalePage', value: true }, // old flag
     { name: 'AREnableCustomSharesheet', value: true },
-    { name: 'AROptionsNewInsightsPage', value: false },
+    { name: 'AROptionsNewInsightsPage', value: false }, // old flag
     { name: 'AREnableReactNativeWebView', value: true },
     { name: 'AROptionsNewArtistInsightsPage', value: true },
   ],


### PR DESCRIPTION
### Description

I will make an issue and a reminder to check back on this. For now, I am marking some flags with `old flag`. That means they are flags that were on echo before the [migration of feature flags infra from native to ts](https://github.com/artsy/eigen/pull/4400). The latest version of the native infra was `6.7.7`. Once there are no or very few users using that version, we can then remove the comment from these flags.

If the `old flag` comment is there, then we must not remove them from echo. Once the comment is not there, then the flag can stay or be removed if it is not used anymore from any eigen code. Most of these are still used in eigen.

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
