### PR TITLE
flag old stuff to be removed later

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -55,11 +55,11 @@
     { name: 'KillSwitchBuildMinimum', content: '5.0.0' },
     { name: 'KillSwitchBuildMinimumAndroid', content: '5.0.0' },
     {
-      name: 'LegacyFairSlugs',
+      name: 'LegacyFairSlugs', // 2021-05-17, removed: artsy/eigen#4785, wait for few or no users with version 6.9.0 to remove from echo
       content: 'ifpda-fine-art-print-fair-online-fall-2020,photo-london-2020,highlights-international-art-fair-munich-2020,2020-art-taipei,1-54-london-2020',
     },
     {
-      name: 'LegacyFairProfileSlugs',
+      name: 'LegacyFairProfileSlugs', // 2021-05-17, removed: artsy/eigen#4785, wait for few or no users with version 6.9.0 to remove from echo
       content: 'ifpda-fine-art-print-fair-online-fall-2020,photo-london-digital-2020,highlights-munich-2020,art-taipei-2020,1-54-london-2020,ifpda-print-fair,photo-london,highlights-munich,art-taipei,1-54',
     },
   ],


### PR DESCRIPTION
### Description

Following up from https://github.com/artsy/eigen/pull/4785, marking these as "can be removed once few of no users are on 6.9.0". Metrics can be found here https://artsy.looker.com/explore/frontend_analytics/eigen_tracks?qid=SZXeeacYh6Hq2CnE9ooGDl&origin_space=712&toggle=fil,vis.

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
