### PR TITLE
feat: disable inquiry checkout until we are ready to release

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -30,7 +30,7 @@
     { name: 'AROptionsNewInsightsPage', value: false },
     { name: 'AREnableReactNativeWebView', value: true },
     { name: 'AROptionsNewArtistInsightsPage', value: true }, // 2021-05-17, removed: artsy/eigen#4753, deployed: 6.4.1
-    { name: 'AROptionsInquiryCheckout', value: true },
+    { name: 'AROptionsInquiryCheckout', value: false },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

Following https://github.com/artsy/eigen/pull/4782#issuecomment-842207430, since we are going to do a _timed release_, let's disable Inquiry Checkout for now and will re-enable it once we are ready to release it.

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
