### PR TITLE
fix: Renames echo flag to match the one in eigen

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -31,7 +31,7 @@
     { name: 'AREnableReactNativeWebView', value: true },
     { name: 'AROptionsNewArtistInsightsPage', value: true }, // 2021-05-17, removed: artsy/eigen#4753, deployed: 6.4.1
     { name: 'AROptionsInquiryCheckout', value: true },
-    { name: 'AROptionsOrderHistory', value: false },
+    { name: 'AREnableOrderHistoryOption', value: false },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

Based on the precedent (and the error I'm getting in CI), this renames the flag to match the [feature name](https://github.com/artsy/eigen/blob/master/src/lib/store/config/features.ts#L97).

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
