### PR TITLE
Add basic dependabot config as per playbook (PLATFORM-3578)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    # Limit to 0 to enable only security updates:
+    open-pull-requests-limit: 0
+    assignees:
+      - pvinis
+    reviewers:
+      - artsy/collector-experience


### PR DESCRIPTION
### Description

This configures automated security patches (only) as per the evolving [playbook](https://www.notion.so/artsy/Security-alerts-and-updates-for-repositories-dependabot-114369231d854ce89b104ea0da5d0c65). @pvinis I nominated you and the CX team since you appear to be the most active contributors, but I'm happy to adjust if there's a better target.

https://artsyproduct.atlassian.net/browse/PLATFORM-3578

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
