### PR TITLE
fix: Deployment failing due to missing aws-cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "64:ce:5e:b5:3f:c5:fe:94:90:7a:fb:d5:5f:c5:a7:ef"
+      - run:
+          name: Install dependencies
+          command: ./scripts/install_dependencies.sh
       - run: ./scripts/deploy.sh
 
 

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,17 @@
+if ! which aws;
+then
+  echo "installing aws"
+  # install awscli
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+  unzip -o -qq awscliv2.zip
+  sudo ./aws/install
+
+  # configure awscli
+  mkdir -p ~/.aws
+  touch ~/.aws/config
+  echo "[default]" >> ~/.aws/config
+  echo "region = us-east-1" >> ~/.aws/config
+  echo "output = json" >> ~/.aws/config
+else
+  echo "aws already installed"
+fi


### PR DESCRIPTION
### Description

While working with @rajsam003  on deploying our latest feature flags, we noticed that the previous deployments have been failing due to missing AWS-CLI. So we added a new step that installs it.

cc @pvinis 

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
