### PR TITLE
fix: use async import for execa

### DIFF
--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -4,7 +4,7 @@ const jsonminify = require('jsonminify')
 const { exit } = require('process')
 const JSON5 = require('json5')
 const jsonschema = require('jsonschema')
-const { execa } = require('execa')
+
 
 const repoDir = `${__dirname}/..`
 const templateFile5 = `${repoDir}/Echo.json5`
@@ -17,6 +17,7 @@ const schema = require('../schema.json')
 
 const prepare = async () => {
   try {
+    const { execa } = await import("execa")
     await envsub({
       templateFile: templateFile5,
       outputFile: outputFile5,


### PR DESCRIPTION
### Description

Uses import instead of require as now required by execa to hopefully fix deployment.

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
