### PR TITLE
[CX-2331]: Remove AROptionsArtistSeries feature flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -22,7 +22,7 @@
     { name: 'AREnableViewingRooms', value: true }, // old flag
     { name: 'AROptionsNewFirstInquiry', value: true }, // old flag
     { name: 'AROptionsBidManagement', value: true }, // old flag
-    { name: 'AROptionsArtistSeries', value: true }, // old flag
+    { name: 'AROptionsArtistSeries', value: true }, // 2021-02-21, removed: artsy/eigen#6171
     { name: 'AROptionsNewFairPage', value: true },
     { name: 'AROptionsNewShowPage', value: true },
     { name: 'AROptionsNewSalePage', value: true }, // old flag


### PR DESCRIPTION
### Description

Removes AROptionsArtistSeries feature flag. The feature is already released for more than a month and the feature flag is not needed anymore.

Jira: [nickskalkin/remove-ar_options_artist_series-ff](https://artsyproduct.atlassian.net/browse/CX-2331)

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
