### PR TITLE
feat: add AREnableMakeOfferOnAllEligibleArtworks

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -59,6 +59,7 @@
     { name: 'ARMyCollectionLocalSortAndFilter', value: true },
     { name: 'AREnableQueriesPrefetching', value: true },
     { name: 'AREnablePlaceholderLayoutAnimation', value: true },
+    { name: 'AREnableMakeOfferOnAllEligibleArtworks', value: true },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

Adds the feature flag for "Make Offer on All Eligible Artworks". We already use this feature flag in other services such as Force and Gravity.

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
