### PR TITLE
Revert "feat: add AREnableMakeOfferOnAllEligibleArtworks"

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -59,7 +59,6 @@
     { name: 'ARMyCollectionLocalSortAndFilter', value: true },
     { name: 'AREnableQueriesPrefetching', value: true },
     { name: 'AREnablePlaceholderLayoutAnimation', value: true },
-    { name: 'AREnableMakeOfferOnAllEligibleArtworks', value: true },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
Reverts artsy/echo#203

Turns out we don't need this extra feature flag for Eigen, controlling the ff from Gravity works super.