### PR TITLE
chore: add collector profile and linking social account feature flags

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -59,6 +59,8 @@
     { name: 'ARMyCollectionLocalSortAndFilter', value: true },
     { name: 'AREnableQueriesPrefetching', value: true },
     { name: 'AREnablePlaceholderLayoutAnimation', value: true },
+    { name: 'ARShowLinkedAccounts', value: true },
+    { name: 'ARAllowLinkSocialAccountsOnSignUp', value: true },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },

--- a/Echo.json5
+++ b/Echo.json5
@@ -61,6 +61,7 @@
     { name: 'AREnablePlaceholderLayoutAnimation', value: true },
     { name: 'ARShowLinkedAccounts', value: true },
     { name: 'ARAllowLinkSocialAccountsOnSignUp', value: true },
+    { name: 'AREnableCollectorProfile', value: false },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

This PR adds:
- The collector profile feature flag to Echo set to `false`. It's disabled for now since we would like to release it at the same time as the CMS profile.
- the linking social accounts related feature flags and sets them to true.

## Note:
**Please make sure to merge this pull request instead of squashing it!**

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
