### PR TITLE
deprecate `AROptionsNewSalePage` and clean up

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""

--- a/Echo.json5
+++ b/Echo.json5
@@ -62,7 +62,7 @@
     { name: 'AROptionsNewArtistInsightsPage', value: true }, // 2021-05-17, removed: artsy/eigen#4753, deployed: 6.4.1
     { name: 'AROptionsNewFirstInquiry', value: true }, // old flag
     { name: 'AROptionsNewInsightsPage', value: false }, // old flag
-    { name: 'AROptionsNewSalePage', value: true }, // old flag
+    { name: 'AROptionsNewSalePage', value: true }, // 2022-03-08, removed: artsy/eigen#6386
     { name: 'AROptionsPriceTransparency', value: true }, // old flag
   ],
   messages: [

--- a/Echo.json5
+++ b/Echo.json5
@@ -6,7 +6,6 @@
   features: [
     { name: 'ipad_vir', value: false },
     { name: 'iphone_vir', value: true },
-    { name: 'ARDisableReactNativeBidFlow', value: false }, // old flag
     { name: 'AREnableBuyNowFlow', value: true },
     { name: 'AREnableMakeOfferFlow', value: true },
     { name: 'AREnableLocalDiscovery', value: true },
@@ -14,27 +13,14 @@
     { name: 'ARReactNativeArtworkEnableNonCommercial', value: true },
     { name: 'ARReactNativeArtworkEnableNSOInquiry', value: true },
     { name: 'ARReactNativeArtworkEnableAuctions', value: true },
-    { name: 'AROptionsPriceTransparency', value: true }, // old flag
-    { name: 'AREnableNewPartnerView', value: true }, // old flag
     { name: 'AREnableNewSearch', value: true },
-    { name: 'AROptionsLotConditionReport', value: true }, // old flag
     { name: 'AROptionsEnableSales', value: true },
-    { name: 'AREnableViewingRooms', value: true }, // old flag
-    { name: 'AROptionsNewFirstInquiry', value: true }, // old flag
-    { name: 'AROptionsBidManagement', value: true }, // old flag
-    { name: 'AROptionsArtistSeries', value: true }, // 2021-02-21, removed: artsy/eigen#6171
     { name: 'AROptionsNewFairPage', value: true },
     { name: 'AROptionsNewShowPage', value: true },
-    { name: 'AROptionsNewSalePage', value: true }, // old flag
     { name: 'AREnableCustomSharesheet', value: true },
-    { name: 'AROptionsNewInsightsPage', value: false }, // old flag
     { name: 'AREnableReactNativeWebView', value: true },
-    { name: 'AROptionsNewArtistInsightsPage', value: true }, // 2021-05-17, removed: artsy/eigen#4753, deployed: 6.4.1
     { name: 'AROptionsInquiryCheckout', value: true },
     { name: 'AREnableOrderHistoryOption', value: true },
-    { name: 'AREnableSavedSearch', value: true }, // 2021-10-07, removed artsy/eigen#5590
-    { name: 'AREnableSavedSearchAndroid', value: false }, // 2021-10-07, removed artsy/eigen#5590
-    { name: 'AREnableSavedSearchV2', value: true }, // 2021-10-07, removed artsy/eigen#5590
     { name: 'AREnableOnlyTargetSupplyConsignments', value: true },
     { name: 'AREnableAuctionResultsKeywordFilter', value: true },
     { name: 'ARHomeAuctionResultsByFollowedArtists', value: true },
@@ -62,6 +48,22 @@
     { name: 'ARShowLinkedAccounts', value: true },
     { name: 'ARAllowLinkSocialAccountsOnSignUp', value: true },
     { name: 'AREnableCollectorProfile', value: false },
+
+    // deprecated flags. REMOVE OR CHANGE WITH CARE.
+    { name: 'ARDisableReactNativeBidFlow', value: false }, // old flag
+    { name: 'AREnableNewPartnerView', value: true }, // old flag
+    { name: 'AREnableSavedSearch', value: true }, // 2021-10-07, removed artsy/eigen#5590
+    { name: 'AREnableSavedSearchAndroid', value: false }, // 2021-10-07, removed artsy/eigen#5590
+    { name: 'AREnableSavedSearchV2', value: true }, // 2021-10-07, removed artsy/eigen#5590
+    { name: 'AREnableViewingRooms', value: true }, // old flag
+    { name: 'AROptionsArtistSeries', value: true }, // 2021-02-21, removed: artsy/eigen#6171
+    { name: 'AROptionsBidManagement', value: true }, // old flag
+    { name: 'AROptionsLotConditionReport', value: true }, // old flag
+    { name: 'AROptionsNewArtistInsightsPage', value: true }, // 2021-05-17, removed: artsy/eigen#4753, deployed: 6.4.1
+    { name: 'AROptionsNewFirstInquiry', value: true }, // old flag
+    { name: 'AROptionsNewInsightsPage', value: false }, // old flag
+    { name: 'AROptionsNewSalePage', value: true }, // old flag
+    { name: 'AROptionsPriceTransparency', value: true }, // old flag
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "echo",
-    "version": "1.0.0",
-    "type": "module",
-    "scripts": {
-        "lint": "prettier --parser json5 --write Echo.json5",
-        "prepare": "husky install"
-    },
-    "dependencies": {
-        "envsub": "^4.0.7",
-        "execa": "^6.1.0",
-        "json5": "^2.2.0",
-        "jsonminify": "^0.4.2",
-        "jsonschema": "^1.4.0",
-        "prettier": "^2.5.1"
-    },
-    "devDependencies": {
-        "husky": "^7.0.4"
-    },
-    "repository": "git@github.com:artsy/echo.git",
-    "author": "Pavlos Vinieratos <pvinis@gmail.com>",
-    "license": "MIT"
+  "name": "echo",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "lint": "prettier --parser json5 --write Echo.json5",
+    "prepare": "husky install"
+  },
+  "dependencies": {
+    "envsub": "4.0.7",
+    "execa": "6.1.0",
+    "json5": "2.2.0",
+    "jsonminify": "0.4.2",
+    "jsonschema": "1.4.0",
+    "prettier": "2.5.1"
+  },
+  "devDependencies": {
+    "husky": "7.0.4"
+  },
+  "repository": "git@github.com:artsy/echo.git",
+  "author": "Pavlos Vinieratos <pvinis@gmail.com>",
+  "license": "MIT"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,7 +53,7 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-envsub@^4.0.7:
+envsub@4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/envsub/-/envsub-4.0.7.tgz#41e326a77696a06e44a2250c5a89371da404f311"
   integrity sha512-Vr2qsbaTeJEstIoT0GlKnoySmvL91b8LI3D/aicuo1styWcNUvfYv3oeFD2lhB1+S6H/e2TvEkZbmhzDM73Okw==
@@ -66,7 +66,7 @@ envsub@^4.0.7:
     lodash "^4.17.15"
     replace-last "^1.2.6"
 
-execa@^6.1.0:
+execa@6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-6.1.0.tgz#cea16dee211ff011246556388effa0818394fb20"
   integrity sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==
@@ -108,7 +108,7 @@ human-signals@^3.0.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
   integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
 
-husky@^7.0.4:
+husky@7.0.4:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
   integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
@@ -123,19 +123,19 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-json5@^2.2.0:
+json5@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
 
-jsonminify@^0.4.2:
+jsonminify@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/jsonminify/-/jsonminify-0.4.2.tgz#fe6fb09391227e856f8c7c0761ff11b497b61fe8"
   integrity sha512-mEtP5ECD0293D+s45JhDutqF5mFCkWY8ClrPFxjSFR2KUoantofky7noSzyKnAnD9Gd8pXHZSUd5bgzLDUBbfA==
 
-jsonschema@^1.4.0:
+jsonschema@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2"
   integrity sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==
@@ -189,7 +189,7 @@ path-key@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
   integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
 
-prettier@^2.5.1:
+prettier@2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==


### PR DESCRIPTION
### Description

Paired with @brainbicycle on:
- moving all the deprecated flags at the bottom
- added info for the newly deprecated `AROptionsNewSalePage` flag
- cleaned up package.json a bit

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
