### PR TITLE
Chore: Mark AROptionsNewFirstInquiry as deprecated

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -20,7 +20,7 @@
     { name: 'AROptionsLotConditionReport', value: true }, // old flag
     { name: 'AROptionsEnableSales', value: true },
     { name: 'AREnableViewingRooms', value: true }, // old flag
-    { name: 'AROptionsNewFirstInquiry', value: true }, // old flag
+    { name: 'AROptionsNewFirstInquiry', value: true }, // 2021-03-14, removed: artsy/eigen#6419
     { name: 'AROptionsBidManagement', value: true }, // old flag
     { name: 'AROptionsArtistSeries', value: true }, // 2021-02-21, removed: artsy/eigen#6171
     { name: 'AROptionsNewFairPage', value: true },


### PR DESCRIPTION
### Description

Added information for the newly deprecated `AROptionsNewFirstInquiry` flag. Related to [NX-3093]

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
