### PR TITLE
chore: force upgrade users below 6.5.0

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -107,7 +107,7 @@
       name: 'StripeStagingPublishableKey',
       content: '${StripeStagingPublishableKey}',
     },
-    { name: 'KillSwitchBuildMinimum', content: '5.0.0' },
+    { name: 'KillSwitchBuildMinimum', content: '6.5.0' },
     { name: 'KillSwitchBuildMinimumAndroid', content: '5.0.0' },
     { name: 'EigenQueryPrefetchingRateLimit', content: '60' },
     {


### PR DESCRIPTION
### Description

We want to retire metaphysics v1 officially, the last Eigen version to use v1 was 6.4.9. 
https://github.com/artsy/eigen/pull/3548

This version 2 years old at this point with few users we should be able to safely upgrade.

### Testing:

Would like to make sure of UX and that we are only upgrading what we want to:
- [x] Build eigen locally with the targeted version 6.4.9 - verify UX is acceptable

![old-killswitch](https://user-images.githubusercontent.com/49686530/181119131-df11d1c5-76b2-41c5-8d61-d9cabb8848b4.png)

- [x] Build eigen locally with a version above the targeted version - verify there is no upgrade forced


### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
