### PR TITLE
chore: add arenablenewimagecomponent flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -61,11 +61,11 @@
     { name: 'AREnableMyCollectionInsights', value: true },
     { name: 'AREnableMyCollectionInsightsPhase1Part1', value: true },
     { name: 'AREnableMyCollectionInsightsPhase1Part2', value: true },
-    { name: 'AREnableNewOpaqueImageView', value: false },
     { name: 'AREnableNewImageComponent', value: false },
     { name: 'AREnableArtworksConnectionForAuction', value: false },
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.
+    { name: 'AREnableNewOpaqueImageView', value: false }, // renamed to AREnableNewImageComponent on 2022-08-23, safe to remove after this pr gets merged
     { name: 'AREnableAccordionNavigationOnSubmitArtwork', value: true }, // 2022-04-20, removed artsy/eigen#6643
     { name: 'ARDisableReactNativeBidFlow', value: false }, // old flag
     { name: 'AREnableImprovedAlertsFlow', value: true }, // 2022-02-07, removed artsy/eigen#6976

--- a/Echo.json5
+++ b/Echo.json5
@@ -62,6 +62,7 @@
     { name: 'AREnableMyCollectionInsightsPhase1Part1', value: true },
     { name: 'AREnableMyCollectionInsightsPhase1Part2', value: true },
     { name: 'AREnableNewOpaqueImageView', value: false },
+    { name: 'AREnableNewImageComponent', value: false },
     { name: 'AREnableArtworksConnectionForAuction', value: false },
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.


### PR DESCRIPTION
### Description

- [x] Renames old FF `AREnableOpaqueImageView` to `AREnableNewImageComponent`
- [x] deprecates the old one to be removed later

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
