### PR TITLE
chore: move cascading end time auction flags to deprecated

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -51,10 +51,6 @@
     { name: 'AREnableCollectorProfile', value: false },
     { name: 'AREnableHomeScreenArtworkRecommendations', value: true },
     { name: 'AREnableMyCollectionComparableWorks', value: false },
-    { name: 'AREnableCascadingEndTimerLotPage', value: true },
-    { name: 'AREnableCascadingEndTimerSalePageGrid', value: true },
-    { name: 'AREnableCascadingEndTimerSalePageDetails', value: true },
-    { name: 'AREnableCascadingEndTimerHomeSalesRail', value: true },
     { name: 'AREnableConversationalBuyNow', value: true },
     { name: 'AREnableArtworksFromNonArtsyArtists', value: false },
     { name: 'AREnableCreateArtworkAlert', value: true },
@@ -68,6 +64,10 @@
     { name: 'AREnableNewRequestPriceEstimateLogic', value: false },
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.
+    { name: 'AREnableCascadingEndTimerLotPage', value: true }, // 2022-11-3 removed artsy/eigen#7579
+    { name: 'AREnableCascadingEndTimerSalePageGrid', value: true }, // 2022-11-3 removed artsy/eigen#7579
+    { name: 'AREnableCascadingEndTimerSalePageDetails', value: true }, // 2022-11-3 removed artsy/eigen#7579
+    { name: 'AREnableCascadingEndTimerHomeSalesRail', value: true }, // 2022-11-3 removed artsy/eigen#7579
     { name: 'AREnableNewImageComponent', value: false }, // renamed to AREnableNewImage on 2022-10-06, safe to remove after this pr gets merged
     { name: 'AREnableNewOpaqueImageView', value: false }, // renamed to AREnableNewImageComponent on 2022-08-23, safe to remove after this pr gets merged
     { name: 'AREnableAccordionNavigationOnSubmitArtwork', value: true }, // 2022-04-20, removed artsy/eigen#6643


### PR DESCRIPTION
### Description

Move cascading end time auction flags to deprecated.

eigen pr https://github.com/artsy/eigen/pull/7579

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
