### PR TITLE
chore: update minimum version on iOS and Android

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -151,8 +151,8 @@
       name: 'StripeStagingPublishableKey',
       content: '${StripeStagingPublishableKey}',
     },
-    { name: 'KillSwitchBuildMinimum', content: '6.5.0' },
-    { name: 'KillSwitchBuildMinimumAndroid', content: '5.0.0' },
+    { name: 'KillSwitchBuildMinimum', content: '8.5.0' },
+    { name: 'KillSwitchBuildMinimumAndroid', content: '6.10.0' },
     { name: 'EigenQueryPrefetchingRateLimit', content: '60' },
     {
       name: 'LegacyFairSlugs', // 2021-05-17, removed: artsy/eigen#4785, wait for few or no users with version 6.9.0 to remove from echo


### PR DESCRIPTION
### Description

Resolves: https://artsyproduct.atlassian.net/browse/MOPLAT-570
Resolves: https://artsyproduct.atlassian.net/browse/MOPLAT-571

Updates the minimum versions of Android and iOS. 
Less than 1% of iOS users on versions below 8.5.0
Should be well below that on Android for 6.10.0

[iOS user turnover](https://artsy.looker.com/explore/frontend_analytics/eigen_screens?qid=tXFcdcTuCYYg16mZ5W7hqt&origin_space=712&toggle=fil,vis)
[Android user turnover](https://play.google.com/console/u/0/developers/6449739225222972501/app/4975007939329818983/statistics?metrics=ACTIVE_USERS-ALL-UNIQUE-PER_INTERVAL-DAY&dimension=APP_VERSION&dimensionValues=OVERALL%2C1674645198%2C1674645184%2C564%2C713%2C731%2C697%2C1674645164%2C511&dateRange=2023_2_21-2023_3_22&tab=APP_STATISTICS&ctpMetric=DAU_MAU-ACQUISITION_UNSPECIFIED-COUNT_UNSPECIFIED-CALCULATION_UNSPECIFIED-DAY&ctpDateRange=2023_2_21-2023_3_22&ctpDimension=COUNTRY&ctpDimensionValue=OVERALL&ctpPeersetKey=3%3Ab44b54d29adff76d)

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
