### PR TITLE
chore: use updated node docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 jobs:
   deploy-json:
     docker:
-      - image: cimg/node:16.10
+      - image: cimg/node:18.15.0
     steps:
       - add_ssh_keys:
           fingerprints:


### PR DESCRIPTION
### Description

Updates the docker image in circle to use updated node

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
