### PR TITLE
feat: enable AREnableArtworkLists feature flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -75,7 +75,7 @@
     { name: 'AREnableNewAuctionsRailCard', value: true },
     { name: 'AREnableStickyTabsLazyLoading', value: true },
     { name: 'AREnableArtworkContextMenu', value: false },
-    { name: 'AREnableArtworkLists', value: false },
+    { name: 'AREnableArtworkLists', value: true },
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.
     { name: 'ARArtworkRedesingPhase2', value: true }, // 2023-02-21 removed artsy/eigen#8244


### PR DESCRIPTION
### Description

Enable `AREnableArtworkLists` feature flag for internal Artsy launch in app version `8.13.0`.

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
