### PR TITLE
feat: refresh AREnableArtworkContextMenu ff

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -74,11 +74,12 @@
     { name: 'AREnableSWALandingPageTestimonials', value: false },
     { name: 'AREnableNewAuctionsRailCard', value: true },
     { name: 'AREnableStickyTabsLazyLoading', value: true },
-    { name: 'AREnableArtworkContextMenu', value: false },
+    { name: 'AREnableLongPressArtworkCards', value: false },
     { name: 'AREnableArtworkLists', value: true },
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.
     { name: 'ARArtworkRedesingPhase2', value: true }, // 2023-02-21 removed artsy/eigen#8244
+    { name: 'AREnableArtworkContextMenu', value: false }, // 2023-06-16 removed artsy/eigen#8895 (before removing make sure that 8.14.0 doesn't have any active users)
     { name: 'AREnableConsignmentInquiryFlow', value: false }, // 10-01-2023 renamed AREnableConsignmentInquiry
     { name: 'AREnableActivity', value: true }, // 2022-12-12 removed artsy/eigen#7847
     { name: 'AREnableNewImage', value: false }, // renamed to AREnableNewOpaqueImageComponent on 2022-11-15


### PR DESCRIPTION
This PR resolves [MOPLAT-819]

### Description 

Deprecates `AREnableArtworkContextMenu` and refreshes it to `AREnableLongPressArtworkCards`.

Reason: 

Before the `8.14.0` release where the `AREnableArtworkContextMenu` was marked as `readyForRelease: true` got some launch blocking design feedback so we are refreshing the feature flag to prevent leaking the feature to `8.14.0` version.

Related eigen PR: https://github.com/artsy/eigen/pull/8895


### Follow ups:

Mark `AREnableLongPressArtworkCards` as ready for release and enable it on echo when feedback is addressed (ticketed [here](https://artsyproduct.atlassian.net/browse/MOPLAT-823))


### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.


[MOPLAT-819]: https://artsyproduct.atlassian.net/browse/MOPLAT-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ