### PR TITLE
feat: enable AREnableArtistSeriesFilter

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -162,7 +162,7 @@
     { name: 'AREnableAlertsFilters', value: true },
     { name: 'AREnableAlertsSuggestedFilters', value: true },
     { name: 'AREnablePartnerOffersNotificationSwitch', value: false },
-    { name: 'AREnableArtistSeriesFilter', value: false },
+    { name: 'AREnableArtistSeriesFilter', value: true },
     { name: 'AREnableNewWorksForYouScreenFeed', value: true },
     { name: 'AREnablePartnerOffer', value: false },
   ],


### PR DESCRIPTION
### Description

This toggles `AREnableArtistSeriesFilter` to `true`, thus enabling the new Artist Series filter and alert support on artist screens

(Further support in artwork screens and the new alert modal still to come, under a separate flag)

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
