### PR TITLE
chore: disable ARShowCollectedArtistOnboarding flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -151,7 +151,7 @@
     { name: 'AREnableAdditionalSiftAndroidTracking', value: true },
     { name: 'AREnableArtworkLists', value: false },
     { name: 'AREnableMyCollectionCollectedArtists', value: true },
-    { name: 'ARShowCollectedArtistOnboarding', value: true },
+    { name: 'ARShowCollectedArtistOnboarding', value: false }, // 2023-12-19, disabled pending removal
     { name: 'AREnableFallbackToGeneratedAlertNames', value: true },
     { name: 'ARShowCreateAlertInArtistArtworksListFooter', value: true },
     { name: 'AREnableLatestActivityRail', value: true },


### PR DESCRIPTION
### Description

Most users this feature initially targeted have now seen the modal and had the opportunity to update sharing settings to previously uploaded works in My Collection. After six months active in the app we've decided to disable this feature pending removal from the app.

cc/ @artsy/onyx-devs 

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
