### PR TITLE
chore: add AREnableSubmitMyCollectionArtworkInSubmitFlow ff

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -183,6 +183,7 @@
     { name: 'AREnableNewSubmissionFlow', value: true },
     { name: 'AREnableLongPressOnNewForYouRail', value: true },
     { name: 'AREnableSaveAndContinueSubmission', value: true },
+    { name: 'AREnableSubmitMyCollectionArtworkInSubmitFlow', value: true },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

This PR adds AREnableSubmitMyCollectionArtworkInSubmitFlow feature flag. This is needed in order to release submit artwork from my collection

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
