### PR TITLE
chore: add new submit artwork from my collection feature flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -184,6 +184,7 @@
     { name: 'AREnableLongPressOnNewForYouRail', value: true },
     { name: 'AREnableSaveAndContinueSubmission', value: true },
     { name: 'AREnableSubmitMyCollectionArtworkInSubmitFlow', value: false },
+    { name: 'AREnableSubmitMyCollectionArtworkInSubmitFlowNew', value: true },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

This PR adds a new flag for submit artwork from my collection. This is required to make sure we don't accidentally release the old code, which was set as `readyForRelease`

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
