### PR TITLE
feat: add AREnableCollectorProfilePrompts

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -185,6 +185,7 @@
     { name: 'AREnableSaveAndContinueSubmission', value: true },
     { name: 'AREnableSubmitMyCollectionArtworkInSubmitFlow', value: false },
     { name: 'AREnableSubmitMyCollectionArtworkInSubmitFlowNew', value: true },
+    { name: 'AREnableCollectorProfilePrompts', value: false },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

This PR adds `AREnableCollectorProfilePrompts` which will be used to build prompts to the user that will encourage them to update their profile or add artists to their collection after they perform commercial actions.

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
