### PR TITLE
chore: sync android minimum version

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -208,7 +208,7 @@
       content: '${StripeStagingPublishableKey}',
     },
     { name: 'KillSwitchBuildMinimum', content: '8.5.0' },
-    { name: 'KillSwitchBuildMinimumAndroid', content: '6.10.1' },
+    { name: 'KillSwitchBuildMinimumAndroid', content: '8.5.0' },
     { name: 'EigenQueryPrefetchingRateLimit', content: '60' },
     {
       name: 'LegacyFairSlugs', // 2021-05-17, removed: artsy/eigen#4785, wait for few or no users with version 6.9.0 to remove from echo


### PR DESCRIPTION
### Description

Sync android killswitch to same minimum as iOS so we can safely remove deprecated features. 

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
