### PR TITLE
feat: add AREnableCollectionsWithoutHeaderImage and flip to true

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -188,6 +188,7 @@
     { name: 'AREnableCollectorProfilePrompts', value: false },
     { name: 'AREnablePartnerOfferSignals', value: false },
     { name: 'AREnableAuctionImprovementsSignals', value: false },
+    { name: 'AREnableCollectionsWithoutHeaderImage', value: true },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

https://github.com/artsy/eigen/pull/10602

Adds ff to hide header image from collections page

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
