### PR TITLE
chore: move collections header ff to the right spot

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -74,6 +74,7 @@
     { name: 'AREnableLongPressOnArtworkCards', value: false },
     { name: 'AREnablePriceControlForCreateAlertFlow', value: true },
     { name: 'ARUsePrincipalFieldErrorHandlerMiddleware', value: true },
+    { name: 'AREnableCollectionsWithoutHeaderImage', value: true },
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.
     { name: 'ARUseNewErrorMiddleware', value: true }, //2023-11-16 removed artsy/eigen#9574
@@ -188,7 +189,6 @@
     { name: 'AREnableCollectorProfilePrompts', value: false },
     { name: 'AREnablePartnerOfferSignals', value: false },
     { name: 'AREnableAuctionImprovementsSignals', value: false },
-    { name: 'AREnableCollectionsWithoutHeaderImage', value: true },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

Moves the `AREnableCollectionsWithoutHeaderImage` to non deprecated 

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
