### PR TITLE
chore: Add AREnableSubmitArtworkTier2Information feature flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -190,6 +190,7 @@
     { name: 'AREnableCollectorProfilePrompts', value: false },
     { name: 'AREnablePartnerOfferSignals', value: false },
     { name: 'AREnableAuctionImprovementsSignals', value: false },
+    { name: 'AREnableSubmitArtworkTier2Information', value: false }
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Post-approval-progress-animation-broken-after-Additional-Documents-step-ac4c7bab00794b5cbc355d4feff074c2?pvs=4

## Description

Add `AREnableSubmitArtworkTier2Information` feature flag.