### PR TITLE
chore: Bump min build for alert operations

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -212,8 +212,8 @@
       name: 'StripeStagingPublishableKey',
       content: '${StripeStagingPublishableKey}',
     },
-    { name: 'KillSwitchBuildMinimum', content: '8.5.0' },
-    { name: 'KillSwitchBuildMinimumAndroid', content: '8.5.0' },
+    { name: 'KillSwitchBuildMinimum', content: '8.36.0' },
+    { name: 'KillSwitchBuildMinimumAndroid', content: '8.36.0' },
     { name: 'EigenQueryPrefetchingRateLimit', content: '60' },
     {
       name: 'LegacyFairSlugs', // 2021-05-17, removed: artsy/eigen#4785, wait for few or no users with version 6.9.0 to remove from echo


### PR DESCRIPTION
Pursuant to the plan for fully removing alert operations from Gravity this PR bumps the min build so that affected Eigen users are required to upgrade. Plan notes here:

https://www.notion.so/artsy/Plan-for-fully-removing-Alert-GQL-operations-from-Gravity-d8ba5abcc70c43d282fafb2c563e1508

And more chatter here:

https://artsy.slack.com/archives/C05F8TNKGAV/p1724778441312399

/cc @artsy/amber-devs