### PR TITLE
chore: turn on AREnableCuratorsPicksAndInterestSignals flag on

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -192,7 +192,7 @@
     { name: 'AREnablePartnerOfferSignals', value: true },
     { name: 'AREnableAuctionImprovementsSignals', value: true },
     { name: 'AREnableSubmitArtworkTier2Information', value: true },
-    { name: 'AREnableCuratorsPicksAndInterestSignals', value: false },
+    { name: 'AREnableCuratorsPicksAndInterestSignals', value: true },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description
This PR turns the `AREnableCuratorsPicksAndInterestSignals` flag on

### PR Checklist (tick all before merging)

- [X] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
