### PR TITLE
feat(art advisor): introduce AREnableDynamicHomeView for M2

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -76,6 +76,7 @@
     { name: 'AREnableCollectionsWithoutHeaderImage', value: true },
     { name: 'ARTesting', value: false },
     { name: 'AREnableArtworkRailRedesignImageAspectRatio', value: false },
+    { name: 'AREnableDynamicHomeView', value: true }, // aka Art Advisor Milestone 2
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.
     { name: 'AREnableNewCollectorSettings', value: true }, // 2024-09-12 removed artsy/eigen#10756


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1305

Counterpart of https://github.com/artsy/eigen/pull/10886

### Description

Introduces a new `AREnableDynamicHomeView` flag to allow the dynamic art advisor home view feature to be toggled.

This is already set to `true`, so merging [eigen/10886](https://github.com/artsy/eigen/pull/10886) will release the feature.

In the event of any issues, we will have the ability to toggle this back to `false` to roll back to the old home screen.

To-do next:

- [x] Add corresponding Eigen flag ([#10886](https://github.com/artsy/eigen/pull/10886))
- [ ] `scripts/setup/update-echo` in Eigen

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
