### PR TITLE
feat: add MP and cacheable CDN feature flags

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -196,6 +196,8 @@
     { name: 'AREnableAuctionImprovementsSignals', value: true },
     { name: 'AREnableSubmitArtworkTier2Information', value: true },
     { name: 'AREnableCuratorsPicksAndInterestSignals', value: true },
+    { name: 'ARUseMetaphysicsCDN', value: true },
+    { name: 'AREnableCacheableDirective', value: true },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

This PR adds the MP CDN and new `@cacheable` directives feature flags.

I am setting the feature flags as ready for release currently to make sure that we have enough time to test things out the upcoming week.


### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
