### PR TITLE
feat: run eigen tests on deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,53 +25,8 @@ jobs:
       - image: cimg/node:18.15.0
     steps:
       - run:
-          name: Trigger eigen workflow and get pipeline ID
-          command: |
-            PIPELINE_ID=$(curl --request POST \
-              --url https://circleci.com/api/v2/project/github/artsy/eigen/pipeline \
-              --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}" \
-              --header 'content-type: application/json' \
-              --data '{"parameters":{"run_workflow_build-run-tests-for-echo":true, "run_workflow_test-build-deploy":false}}' \
-              | jq -r '.id')
-            
-            echo "Triggered eigen pipeline: $PIPELINE_ID"
-
-      - run:
-          name: Poll for eigen workflow status
-          command: |
-            STATUS="running"
-            WORKFLOW_ID=""
-            while [ "$STATUS" == "running" ] || [ -z "$WORKFLOW_ID" ]; do
-              echo "Checking eigen workflow status..."
-
-              # Fetch the workflows associated with the pipeline
-              RESPONSE=$(curl --request GET \
-                --url https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow \
-                --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}")
-
-              WORKFLOW_ID=$(echo $RESPONSE | jq -r '.items[0].id')
-
-              if [ -z "$WORKFLOW_ID" ] || [ "$WORKFLOW_ID" == "null" ]; then
-                echo "Workflow not yet created, waiting for 1 minute before retrying..."
-                sleep 60  # Wait for 1 minute before checking again
-                continue
-              fi
-
-              STATUS=$(echo $RESPONSE | jq -r '.items[0].status')
-
-              echo "Current status: $STATUS"
-
-              if [ "$STATUS" == "success" ]; then
-                echo "Eigen workflow succeeded."
-                exit 0
-              elif [ "$STATUS" == "failed" ]; then
-                echo "Eigen workflow failed."
-                exit 1
-              fi
-
-              echo "Workflow still running, waiting for 5 minutes before checking again..."
-              sleep 300  # Wait for 5 minutes before checking again
-            done
+          name: Run eigen tests
+          command: ./scripts/run_eigen_tests.sh
 
 workflows:
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
           command: |
             curl --location --request POST 'https://circleci.com/api/v2/project/github/artsy/eigen/pipeline' \
             --header 'Content-Type: application/json' \
-            -u "${EIGEN_ECHO_API_TOKEN}:"
+            -u "${EIGEN_ECHO_API_TOKEN}:\
+            --data '{"parameters":{"run_workflow_build-run-tests-for-echo":false}}"
 
 workflows:
   deploy:
@@ -43,10 +44,10 @@ workflows:
                  - fix-ci
           context: echo
       - run-eigen-tests:
-          filters:
-              branches:
-                only:
-                  - main
-                  - production
-                  - fix-ci
+          # filters:
+              # branches:
+              #   only:
+              #     - main
+              #     - production
+              #     - fix-ci
           context: echo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: |
             curl --request POST \
               --url https://circleci.com/api/v2/project/github/artsy/eigen/pipeline \
-              --header 'Circle-Token: ${EIGEN_ECHO_API_TOKEN}' \
+              --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}" \
               --header 'content-type: application/json' \
               --data '{"parameters":{"run_workflow_build-run-tests-for-echo":false}}'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
     docker:
       - image: cimg/node:18.15.0
     steps:
+      - checkout
       - run:
           name: Run eigen tests
           command: ./scripts/run_eigen_tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
               --url https://circleci.com/api/v2/project/github/artsy/eigen/pipeline \
               --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}" \
               --header 'content-type: application/json' \
-              --data '{"parameters":{"run_workflow_build-run-tests-for-echo":false, "run_workflow_test-build-deploy":true}}'
+              --data '{"parameters":{"run_workflow_build-run-tests-for-echo":true, "run_workflow_test-build-deploy":false}}'
 
 workflows:
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,10 @@ workflows:
                  - fix-ci
           context: echo
       - run-eigen-tests:
-          # filters:
-              # branches:
-              #   only:
-              #     - main
-              #     - production
-              #     - fix-ci
+          filters:
+              branches:
+                only:
+                  - main
+                  - production
+                  - fix-ci
           context: echo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,13 +25,40 @@ jobs:
       - image: cimg/node:18.15.0
     steps:
       - run:
-          name: Trigger eigen workflow
+          name: Trigger eigen workflow and get pipeline ID
           command: |
-            curl --request POST \
+            PIPELINE_ID=$(curl --request POST \
               --url https://circleci.com/api/v2/project/github/artsy/eigen/pipeline \
               --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}" \
               --header 'content-type: application/json' \
-              --data '{"parameters":{"run_workflow_build-run-tests-for-echo":true, "run_workflow_test-build-deploy":false}}'
+              --data '{"parameters":{"run_workflow_build-run-tests-for-echo":true, "run_workflow_test-build-deploy":false}}' \
+              | jq -r '.id')
+            
+            echo "Triggered eigen pipeline: $PIPELINE_ID"
+
+      - run:
+          name: Poll for eigen workflow status
+          command: |
+            STATUS="running"
+            while [ "$STATUS" == "running" ]; do
+              echo "Checking eigen workflow status..."
+              STATUS=$(curl --request GET \
+                --url https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow \
+                --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}" \
+                | jq -r '.items[0].status')
+              
+              echo "Current status: $STATUS"
+
+              if [ "$STATUS" == "success" ]; then
+                echo "Eigen workflow succeeded."
+                exit 0
+              elif [ "$STATUS" == "failed" ]; then
+                echo "Eigen workflow failed."
+                exit 1
+              fi
+
+              sleep 300  # Wait 5 minutes before checking again
+            done
 
 workflows:
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,11 @@ jobs:
       - run:
           name: Trigger eigen workflow
           command: |
-            curl --location --request POST 'https://circleci.com/api/v2/project/github/artsy/eigen/pipeline' \
-            --header 'Content-Type: application/json' \
-            -u "${EIGEN_ECHO_API_TOKEN}:\
-            --data '{"parameters":{"run_workflow_build-run-tests-for-echo":false}}"
+            curl --request POST \
+              --url https://circleci.com/api/v2/project/github/artsy/eigen/pipeline \
+              --header 'Circle-Token: ${EIGEN_ECHO_API_TOKEN}' \
+              --header 'content-type: application/json' \
+              --data '{"parameters":{"run_workflow_build-run-tests-for-echo":false}}'
 
 workflows:
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,25 @@ jobs:
           name: Poll for eigen workflow status
           command: |
             STATUS="running"
-            while [ "$STATUS" == "running" ]; do
+            WORKFLOW_ID=""
+            while [ "$STATUS" == "running" ] || [ -z "$WORKFLOW_ID" ]; do
               echo "Checking eigen workflow status..."
-              STATUS=$(curl --request GET \
+
+              # Fetch the workflows associated with the pipeline
+              RESPONSE=$(curl --request GET \
                 --url https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow \
-                --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}" \
-                | jq -r '.items[0].status')
-              
+                --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}")
+
+              WORKFLOW_ID=$(echo $RESPONSE | jq -r '.items[0].id')
+
+              if [ -z "$WORKFLOW_ID" ] || [ "$WORKFLOW_ID" == "null" ]; then
+                echo "Workflow not yet created, waiting for 1 minute before retrying..."
+                sleep 60  # Wait for 1 minute before checking again
+                continue
+              fi
+
+              STATUS=$(echo $RESPONSE | jq -r '.items[0].status')
+
               echo "Current status: $STATUS"
 
               if [ "$STATUS" == "success" ]; then
@@ -57,7 +69,8 @@ jobs:
                 exit 1
               fi
 
-              sleep 300  # Wait 5 minutes before checking again
+              echo "Workflow still running, waiting for 5 minutes before checking again..."
+              sleep 300  # Wait for 5 minutes before checking again
             done
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - image: cimg/node:18.15.0
     steps:
       - run:
-          name: Kick off new pipeline
+          name: Trigger eigen workflow
           command: |
             curl --location --request POST 'https://circleci.com/api/v2/project/github/artsy/eigen/pipeline' \
             --header 'Content-Type: application/json' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
               --url https://circleci.com/api/v2/project/github/artsy/eigen/pipeline \
               --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}" \
               --header 'content-type: application/json' \
-              --data '{"parameters":{"run_workflow_build-run-tests-for-echo":false}}'
+              --data '{"parameters":{"run_workflow_build-run-tests-for-echo":false, "run_workflow_test-build-deploy":true}}'
 
 workflows:
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,16 @@ jobs:
           name: Install dependencies
           command: ./scripts/install_dependencies.sh
       - run: ./scripts/deploy.sh
-
+  run-eigen-tests:
+    docker:
+      - image: cimg/node:18.15.0
+    steps:
+      - run:
+          name: Kick off new pipeline
+          command: |
+            curl --location --request POST 'https://circleci.com/api/v2/project/github/artsy/eigen/pipeline' \
+            --header 'Content-Type: application/json' \
+            -u "${EIGEN_ECHO_API_TOKEN}:"
 
 workflows:
   deploy:
@@ -32,4 +41,12 @@ workflows:
                  - main
                  - production
                  - fix-ci
+          context: echo
+      - run-eigen-tests:
+          filters:
+              branches:
+                only:
+                  - main
+                  - production
+                  - fix-ci
           context: echo

--- a/scripts/run_eigen_tests.sh
+++ b/scripts/run_eigen_tests.sh
@@ -3,6 +3,7 @@ set -euxo pipefail
 
 echo "Running Eigen tests"
 
+# Trigger the test pipeline
 PIPELINE_ID=$(curl --request POST \
               --url https://circleci.com/api/v2/project/github/artsy/eigen/pipeline \
               --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}" \
@@ -12,7 +13,7 @@ PIPELINE_ID=$(curl --request POST \
 
 echo "Triggered eigen pipeline: $PIPELINE_ID"
 
-# wait for pipeline to finish
+# Wait for pipeline to finish
 STATUS="running"
 WORKFLOW_ID=""
 while [ "$STATUS" == "running" ] || [ -z "$WORKFLOW_ID" ]; do
@@ -25,8 +26,8 @@ while [ "$STATUS" == "running" ] || [ -z "$WORKFLOW_ID" ]; do
   WORKFLOW_ID=$(echo $RESPONSE | jq -r '.items[0].id')
 
   if [ -z "$WORKFLOW_ID" ] || [ "$WORKFLOW_ID" == "null" ]; then
-    echo "Workflow not yet created, waiting for 1 minute before retrying..."
-    sleep 30  # Wait for 30s before checking again
+    echo "Workflow not yet created, waiting for 30s before retrying..."
+    sleep 30
     continue
   fi
 
@@ -43,5 +44,5 @@ while [ "$STATUS" == "running" ] || [ -z "$WORKFLOW_ID" ]; do
   fi
 
   echo "Workflow still running, waiting for 30s before checking again..."
-  sleep 30  # Wait for 5 minutes before checking again
+  sleep 30
 done

--- a/scripts/run_eigen_tests.sh
+++ b/scripts/run_eigen_tests.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+echo "Running Eigen tests"
+
+PIPELINE_ID=$(curl --request POST \
+              --url https://circleci.com/api/v2/project/github/artsy/eigen/pipeline \
+              --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}" \
+              --header 'content-type: application/json' \
+              --data '{"parameters":{"run_workflow_build-run-tests-for-echo":true, "run_workflow_test-build-deploy":false}}' \
+              | jq -r '.id')
+
+echo "Triggered eigen pipeline: $PIPELINE_ID"
+
+# wait for pipeline to finish
+STATUS="running"
+WORKFLOW_ID=""
+while [ "$STATUS" == "running" ] || [ -z "$WORKFLOW_ID" ]; do
+  echo "Checking eigen workflow status..."
+  # Fetch the workflows associated with the pipeline
+  RESPONSE=$(curl --request GET \
+              --url https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow \
+              --header "Circle-Token: ${EIGEN_ECHO_API_TOKEN}")
+
+  WORKFLOW_ID=$(echo $RESPONSE | jq -r '.items[0].id')
+
+  if [ -z "$WORKFLOW_ID" ] || [ "$WORKFLOW_ID" == "null" ]; then
+    echo "Workflow not yet created, waiting for 1 minute before retrying..."
+    sleep 30  # Wait for 30s before checking again
+    continue
+  fi
+
+  STATUS=$(echo $RESPONSE | jq -r '.items[0].status')
+
+  echo "Current status: $STATUS"
+
+  if [ "$STATUS" == "success" ]; then
+    echo "Eigen workflow succeeded."
+    exit 0
+   elif [ "$STATUS" == "failed" ]; then
+    echo "Eigen workflow failed."
+    exit 1
+  fi
+
+  echo "Workflow still running, waiting for 30s before checking again..."
+  sleep 30  # Wait for 5 minutes before checking again
+done


### PR DESCRIPTION
### Description

Run eigen tests before deploying echo in order to catch test failures due to echo values changing before deployment.

- triggers eigen test workflow that downloads staging echo json
- waits for the workflow to return success or failure

Example failing run [here](https://app.circleci.com/pipelines/github/artsy/echo/1753/workflows/0807331f-d6d4-4790-a97b-5e51ec962c8e/jobs/750) 

Example succeeding run [here](https://app.circleci.com/pipelines/github/artsy/echo/1754/workflows/174bdbb2-e841-4778-894f-64de639dcb16/jobs/751)

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
