### PR TITLE
feat: annotate AREnableCollectorProfilePrompts and AREnablePartnerOfferSignals retirement date

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -193,10 +193,10 @@
     { name: 'AREnableSubmitMyCollectionArtworkInSubmitFlow', value: false },
     { name: 'AREnableSubmitMyCollectionArtworkInSubmitFlowNew', value: true },
     { name: 'AREnableCollectorProfilePrompts', value: true }, // 2024-08-26, removed artsy/eigen#11038
-    { name: 'AREnablePartnerOfferSignals', value: true },
+    { name: 'AREnablePartnerOfferSignals', value: true }, // 2024-10-22, removed artsy/eigen#10992
     { name: 'AREnableAuctionImprovementsSignals', value: true },
     { name: 'AREnableSubmitArtworkTier2Information', value: true },
-    { name: 'AREnableCuratorsPicksAndInterestSignals', value: true },
+    { name: 'AREnableCuratorsPicksAndInterestSignals', value: true }, // 2024-10-23, removed artsy/eigen#11004
     { name: 'ARUseMetaphysicsCDN', value: true },
     { name: 'AREnableCacheableDirective', value: false },
     { name: 'AREnablePaymentFailureBanner', value: false },


### PR DESCRIPTION
### Description

This PR marks 2 feature flags as deprecated.



### PR Checklist (tick all before merging)

- [X] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
