### PR TITLE
chore: turn AREnablePaymentFailureBanner and AREnableHomeViewTasksSection feature flags on

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -200,8 +200,8 @@
     { name: 'AREnableCuratorsPicksAndInterestSignals', value: true }, // 2024-10-23, removed artsy/eigen#11004
     { name: 'ARUseMetaphysicsCDN', value: true },
     { name: 'AREnableCacheableDirective', value: false },
-    { name: 'AREnablePaymentFailureBanner', value: false },
-    { name: 'AREnableHomeViewTasksSection', value: false },
+    { name: 'AREnablePaymentFailureBanner', value: true },
+    { name: 'AREnableHomeViewTasksSection', value: true },
     { name: 'AREnableCacheableDirective', value: true },
   ],
   messages: [


### PR DESCRIPTION
### Description
This PR turns on both `AREnablePaymentFailureBanner` and `AREnableHomeViewTasksSection` to release the two features on Eigen


### PR Checklist (tick all before merging)

- [X] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
