### PR TITLE
fix: disable cacheable directive in old builds

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -204,7 +204,6 @@
     { name: 'AREnableCacheableDirective', value: false },
     { name: 'AREnablePaymentFailureBanner', value: true },
     { name: 'AREnableHomeViewTasksSection', value: true }, // 2024-11-26, removed artsy/eigen#11197
-    { name: 'AREnableCacheableDirective', value: true },
     { name: 'AREnableNewNavigation', value: true },
     { name: 'AREnableNewSearchModal', value: true }, // 2025-01-08, removed artsy/eigen#11347
     { name: 'AREnableAvailabilityFilter', value: true },


### PR DESCRIPTION
### Description

Disables cacheable directive in older builds to mitigate fair results not returning. 


### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
