### PR TITLE
fix: Increase Eigen query prefetching rate limit to 180

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -237,7 +237,7 @@
     },
     { name: 'KillSwitchBuildMinimum', content: '8.36.0' },
     { name: 'KillSwitchBuildMinimumAndroid', content: '8.36.0' },
-    { name: 'EigenQueryPrefetchingRateLimit', content: '60' },
+    { name: 'EigenQueryPrefetchingRateLimit', content: '180' },
     {
       name: 'LegacyFairSlugs', // 2021-05-17, removed: artsy/eigen#4785, wait for few or no users with version 6.9.0 to remove from echo
       content: 'ifpda-fine-art-print-fair-online-fall-2020,photo-london-2020,highlights-international-art-fair-munich-2020,2020-art-taipei,1-54-london-2020',


### PR DESCRIPTION
Addresses [ONYX-1621]

## Description

This PR increases the query prefetching rate limit for Eigen from `60` to `180` requests per minute. When scrolling a lot on Eigen's home screen, I sometimes reached the rate limit.

[ONYX-1621]: https://artsyproduct.atlassian.net/browse/ONYX-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ