### PR TITLE
fix(favorites): remove duplicate flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -86,7 +86,7 @@
     { name: 'AREnableArtworkCardContextMenuAndroid', value: true },
     { name: 'AREnableLongPressContextMenuOnboarding', value: false },
     { name: 'AREnableHomeViewQuickLinks', value: true },
-    { name: 'AREnableFavoritesTab', value: false },
+    { name: 'AREnableFavoritesTab', value: true },
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.
     { name: 'AREnableNewCollectorSettings', value: true }, // 2024-09-12 removed artsy/eigen#10756
@@ -215,7 +215,6 @@
     { name: 'AREnableViewPortPrefetching', value: true },
     { name: 'AREnableFramedFilter', value: true },
     { name: 'AREnableInfiniteDiscovery', value: true },
-    { name: 'AREnableFavoritesTab', value: true },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

See: [thread](https://artsy.slack.com/archives/C05EQL4R5N0/p1745262361819789)

Data team noticed that this feature didn't actually seem to be released, and that it has only been seen by Artsy testers.

I noticed this flag duplication, hoping this is the root cause (even if not, we should clean it up).

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
