### PR TITLE
feat: add validation to prevent duplicate feature names

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -25,7 +25,6 @@
     { name: 'AREnableMedianPriceChartCareerHighlights', value: true },
     { name: 'AREnableMoneyFormattingInMyCollectionForm', value: true },
     { name: 'AREnableMyCollectionAndroid', value: true },
-    { name: 'AREnableMyCollectionComparableWorks', value: false },
     { name: 'AREnableMyCollectionInsights', value: true },
     { name: 'AREnableMyCollectionInsightsPhase1Part1', value: true },
     { name: 'AREnableMyCollectionInsightsPhase1Part2', value: true },

--- a/scripts/checkForDuplicateFeatures.js
+++ b/scripts/checkForDuplicateFeatures.js
@@ -1,0 +1,33 @@
+import fs from 'fs'
+import json5 from 'json5'
+
+export function checkForDuplicateFeatures(filePath) {
+  const fileContent = fs.readFileSync(filePath, 'utf8')
+  const { features } = json5.parse(fileContent)
+  const rawLines = fileContent.split('\n')
+
+  const featureNames = new Map()
+
+  features.map((feature) => {
+    if (featureNames.has(feature.name)) {
+      const firstOccurrence = featureNames.get(feature.name)
+      const currentOccurrence =
+        rawLines.findIndex((line, lineNumber) => {
+          return (
+            lineNumber > firstOccurrence &&
+            line.includes(`name: '${feature.name}'`)
+          )
+        }) + 1
+
+      throw new Error(
+        `Duplicate feature name "${feature.name}" found.\n` +
+          `First occurrence: line ${firstOccurrence}\n` +
+          `Duplicate occurrence: line ${currentOccurrence}`,
+      )
+    }
+
+    const firstOccurrence =
+      rawLines.findIndex((line) => line.includes(`name: '${feature.name}'`)) + 1
+    featureNames.set(feature.name, firstOccurrence)
+  })
+}

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -1,11 +1,11 @@
-import fs from "fs"
+import fs from 'fs'
 import envsub from 'envsub'
 import jsonminify from 'jsonminify'
-import { exit }  from 'process'
+import { exit } from 'process'
 import JSON5 from 'json5'
 import jsonschema from 'jsonschema'
 import { execa } from 'execa'
-
+import { checkForDuplicateFeatures } from './checkForDuplicateFeatures.js'
 
 const __dirname = new URL('.', import.meta.url).pathname
 
@@ -42,6 +42,8 @@ const prepare = async () => {
         'Did not pass schema validation: ' + JSON.stringify(validation.errors)
       )
     }
+
+    checkForDuplicateFeatures(outputFile5)
 
     const regularJSON = JSON.stringify(json)
     fs.writeFileSync(outputFile, regularJSON)


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1683

### Description

A duplicate Echo feature [interfered with a release](https://artsy.slack.com/archives/C05EQL4R5N0/p1745262361819789) recently.

Let’s prevent that in the future

This adds a dupe check into the existing validation, which already runs as a commit hook.

That means that this new check immediately surfaced a 3-year-old dupe that's been hanging around in Echo:

```
Error: Duplicate feature name "AREnableMyCollectionComparableWorks" found.
First occurrence: line 28
Duplicate occurrence: line 132
```

I was forced to fix that before I could commit my changes here — so the system works 🎉  

(@dariakoko @MounirDhahri please confirm, but I believe it's safe to remove this ancient `AREnableMyCollectionComparableWorks` flag)

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
