### PR TITLE
feat: add AREnableBlueActivityDots flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -88,6 +88,7 @@
     { name: 'AREnableQuickLinksAnimation', value: false },
     { name: 'AREnableQuickLinksAnimation2', value: true },
     { name: 'AREnableRedesignedSettings', value: true },
+    { name: 'AREnableBlueActivityDots', value: false },
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.
     { name: 'AREnableInfiniteDiscovery', value: true }, // 2025-04-24 removed artsy/eigen#11769


### PR DESCRIPTION
### Description

Puts the recent changes to the activity dot (https://github.com/artsy/eigen/pull/12391) behind a flag so that it can be enabled remotely.

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
