### PR TITLE
chore: deprecate AREnableBlueActivityDots

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -88,7 +88,6 @@
     { name: 'AREnableQuickLinksAnimation', value: false },
     { name: 'AREnableQuickLinksAnimation2', value: true },
     { name: 'AREnableRedesignedSettings', value: true },
-    { name: 'AREnableBlueActivityDots', value: true },
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.
     { name: 'AREnableInfiniteDiscovery', value: true }, // 2025-04-24 removed artsy/eigen#11769
@@ -221,6 +220,7 @@
     { name: 'ARDarkModeSupport', value: true },
     { name: 'ARDarkModeOnboarding', value: true },
     { name: 'AREnableNewOrderDetails', value: true },
+    { name: 'AREnableBlueActivityDots', value: true }, // 2025-07-17, removed artsy/eigen/pull/12493
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
### Description

Moves `AREnableBlueActivityDots` to the deprecated area with a pointer to the correspdonding Eigen PR https://github.com/artsy/eigen/pull/12493

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.
