### PR TITLE
chore(EMI-2507): deprecate AREnableNewOrderDetails

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -221,7 +221,7 @@
     { name: 'AREnableFavoritesTab', value: true },
     { name: 'ARDarkModeSupport', value: true },
     { name: 'ARDarkModeOnboarding', value: true },
-    { name: 'AREnableNewOrderDetails', value: true },
+    { name: 'AREnableNewOrderDetails', value: true }, // 2025-08-18,  removed artsy/eigen#12634
     { name: 'AREnableBlueActivityDots', value: true }, // 2025-07-17, removed artsy/eigen/pull/12493
     { name: 'AREnableProgressiveOnboardingPriceRangeHome', value: true },
     { name: 'AREnablePriceRangeToast', value: false },


### PR DESCRIPTION
This PR resolves [EMI-2507]

### Description
This PR is a follow-up on artsy/eigen#12634
This PR marks `AREnableNewOrderDetails` as removed in Echo

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.


[EMI-2507]: https://artsyproduct.atlassian.net/browse/EMI-2507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ