### PR TITLE
chore: fix typo when denying claude access to remote commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
       "Read(.env)",
       "Read(.env.shared)",
       "Bash(hokusai:*)",
-      "Bash(aws:*)]"
+      "Bash(aws:*)"
     ]
   }
 }


### PR DESCRIPTION
chore: fix typo when denying claude access to remote commands