### PR TITLE
chore(TOP-207): Deprecate `AREnableArtworksFramedSize`

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -232,7 +232,7 @@
     { name: 'AREnableFeatureVideoPhase2Type', value: true },
     { name: 'AREnableExpandedCityGuide', value: true },
     { name: 'AREnableArtworksConnectionForAuction2', value: true },
-    { name: 'AREnableArtworksFramedSize', value: true },
+    { name: 'AREnableArtworksFramedSize', value: true }, // 2026-05-12, removed: artsy/eigen#13542
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
This PR resolves part of [TOP-207]

### Description
This PR is a follow-up on artsy/eigen#13542
This PR marks `AREnableArtworksFramedSize` as removed in Echo


### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.


[TOP-207]: https://artsyproduct.atlassian.net/browse/TOP-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ