### PR TITLE
feat(mobile): add AREnableExperienceBasedOnboarding feature flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -233,6 +233,7 @@
     { name: 'AREnableExpandedCityGuide', value: true },
     { name: 'AREnableArtworksConnectionForAuction2', value: true },
     { name: 'AREnableArtworksFramedSize', value: true }, // 2026-05-12, removed: artsy/eigen#13542
+    { name: 'AREnableExperienceBasedOnboarding', value: false },
   ],
   messages: [
     { name: 'LiveAuctionsCurrentWebSocketVersion', content: '3' },


### PR DESCRIPTION
- Adds `AREnableExperienceBasedOnboarding` flag, set to `false`
- This flag gates the experience-based onboarding feature in the Artsy mobile app
- Will be flipped to `true` when the feature is ready to roll out

🤖 Generated with [Claude Code](https://claude.com/claude-code)