### PR TITLE
feat: enable AREnableFollowShowsAndFairs flag

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -220,6 +220,7 @@
     { name: 'AREnableViewPortPrefetching', value: true },
     { name: 'AREnableFramedFilter', value: true },
     { name: 'AREnableFavoritesTab', value: true },
+    { name: 'AREnableFollowShowsAndFairs', value: true },
     { name: 'ARDarkModeSupport', value: true },
     { name: 'ARDarkModeOnboarding', value: true },
     { name: 'AREnableNewOrderDetails', value: true }, // 2025-08-18,  removed artsy/eigen#12634


### PR DESCRIPTION
### Description

Turns on the `AREnableFollowShowsAndFairs` feature flag, set to `true`.

This flag is defined client-side in eigen (`src/app/store/config/features.ts`) with `echoFlagKey: "AREnableFollowShowsAndFairs"`. This PR sets its value in echo so the flag is enabled.

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.

Assisted-by: Claude:Sonnet-5