### PR TITLE
chore(DI-453): Deprecate `AREnableExperienceBasedOnboarding` and `ARShowOnboardingPriceRangeScreen`

### DIFF
--- a/Echo.json5
+++ b/Echo.json5
@@ -90,9 +90,10 @@
     { name: 'AREnableQuickLinksAnimation', value: false },
     { name: 'AREnableQuickLinksAnimation2', value: true },
     { name: 'AREnableRedesignedSettings', value: true },
-    { name: 'ARShowOnboardingPriceRangeScreen', value: true },
 
     // deprecated flags. REMOVE OR CHANGE WITH CARE.
+    { name: 'ARShowOnboardingPriceRangeScreen', value: true }, // 2026-09-08 removed artsy/eigen#14036
+    { name: 'AREnableExperienceBasedOnboarding', value: true }, // 2026-09-08 removed artsy/eigen#14036
     { name: 'AREnableInfiniteDiscovery', value: true }, // 2025-04-24 removed artsy/eigen#11769
     { name: 'AREnableNewCollectorSettings', value: true }, // 2024-09-12 removed artsy/eigen#10756
     { name: 'ARUseNewErrorMiddleware', value: true }, //2023-11-16 removed artsy/eigen#9574
@@ -235,7 +236,6 @@
     { name: 'AREnableExpandedCityGuide', value: true },
     { name: 'AREnableArtworksConnectionForAuction2', value: true }, // 2026-06-17, removed: artsy/eigen#13661
     { name: 'AREnableArtworksFramedSize', value: true }, // 2026-05-12, removed: artsy/eigen#13542
-    { name: 'AREnableExperienceBasedOnboarding', value: true },
     { name: 'AREnableConversationsRealtime', value: true },
     { name: 'AREnableTrendingSearchesInSearchModal', value: true },
     { name: 'AREnableArtsyLens', value: false },


### PR DESCRIPTION
### Description

This PR is a follow-up on artsy/eigen#14036
This PR marks `AREnableExperienceBasedOnboarding` and `ARShowOnboardingPriceRangeScreen` as removed in Echo.

### PR Checklist (tick all before merging)

- [x] I have not stored any sensitive keys/values/information in `Echo.json5` and in CI, or I have not changed anything in that file.

Assisted-by: Claude:Sonnet-5

> This change is related to [DI-453](https://www.notion.so/396cab0764a080bda81fc72c9f957e0a)